### PR TITLE
Update hex2bin.py

### DIFF
--- a/datalogger/modbus/hex2bin.py
+++ b/datalogger/modbus/hex2bin.py
@@ -79,12 +79,12 @@ def convert():
                 parity_bit = parity_func(binary(hexint1) + binary(hexint2), parityBit)
                 if(parityBit == "4"):
                     #startBit+8_bit_msg+stopBit 
-                    #msg = startBit + binary(hexint1) + binary(hexint2) + stopBit
-                    msg = startBit + binary(hexint1)[::-1] + binary(hexint2)[::-1] + stopBit
+                    #msg = startBit + binary(hexint2) + binary(hexint1) + stopBit
+                    msg = startBit + binary(hexint2)[::-1] + binary(hexint1)[::-1] + stopBit
                 else:
                     #startBit+8_bit_msg+parityBit+stopBit 
-                    #msg = startBit + binary(hexint1) +binary(hexint2) + parityBit + stopBit
-                    msg = startBit + binary(hexint1)[::-1] + binary(hexint2)[::-1] + parity_bit + stopBit
+                    #msg = startBit + binary(hexint2) +binary(hexint1) + parity_bit + stopBit
+                    msg = startBit + binary(hexint2)[::-1] + binary(hexint1)[::-1] + parity_bit + stopBit
                 
                 #creates the modbus message
                 modbusMsg = modbusMsg + msg


### PR DESCRIPTION
Fixed the bug for the hex2bin.py. 
If the input is EAF0, then the binary is 1110 1010 1111 0000. 
Then after using the Python file, it should be 0101 0111 0000 1111 with the start, stop, and parity bit added in the appropriate areas.